### PR TITLE
change imagemagick config to fix gif to png error on startup

### DIFF
--- a/templates/alfresco-global.properties.erb
+++ b/templates/alfresco-global.properties.erb
@@ -78,18 +78,23 @@ ooo.exe=<%= @lo_install_loc %>/program/soffice
 ooo.enabled=true
 ooo.port=8100
 swf.exe=/usr/local/bin/pdf2swf
+img.root=/usr/lib/ImageMagick-6.6.9/config
+img.coders=/usr/lib/ImageMagick-6.6.9/modules-Q16/coders
+img.dyn=/usr/lib
 img.exe=<%= @alfresco_base_dir %>/bin/limitconvert.sh
+img.gslib=/usr/share/ghostscript/current/lib
+
 #img.exe=/usr/bin/convert
-img.root=/etc/ImageMagick
-img.config=${img.root}
+#img.root=/etc/ImageMagick
+#img.config=${img.root}
 # Check this path if you get "no decode delegate for this image format" error
 #img.coders=/usr/lib/ImageMagick/modules-Q16/coders
 #img.dyn=/usr/local/lib
 #img.gslib=/usr/local/lib
 
 # TODO will this work with CentOS? prob not
-img.gslib=/usr/share/ghostscript/current/lib
-img.coders=/usr/lib/x86_64-linux-gnu/ImageMagick-6.7.7/modules-Q16/coders
+#img.gslib=/usr/share/ghostscript/current/lib
+#img.coders=/usr/lib/x86_64-linux-gnu/ImageMagick-6.7.7/modules-Q16/coders
 
 #
 # Index


### PR DESCRIPTION
changes to alfresco-global, to fix the error on startup with imagemagick, gif to png.  not sure if hardcoding the imagemagick version is a good plan, wonder can we have a ln so imagemagick path is version independent.  confirmed this change fixed error on vagrant build for ubuntu, will test on centos