### PR TITLE
Change dependency name separator to a slash

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,8 +6,8 @@
 	"license": "unlicensed",
 	"source": "http://github.com/marsbard/puppet-alfresco",
 	"dependencies": [
-		{ "name": "puppetlabs-stdlib" },
-		{ "name": "puppetlabs-mysql" }
+		{ "name": "puppetlabs/stdlib" },
+		{ "name": "puppetlabs/mysql" }
 	]
 		
 


### PR DESCRIPTION
This is a legacy problem with Puppet, and should be fixed in 4.0. For compatibility with 3.x, use slashes instead.
More info: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#dependencies-in-metadatajson