### PR TITLE
Issue 43

### DIFF
--- a/config/backup_install.sh
+++ b/config/backup_install.sh
@@ -8,3 +8,6 @@ then
 else
   puppet apply --modulepath=modules do_backup.pp
 fi
+
+# TODO this really needs to be done by bashconf
+exit

--- a/config/backup_output.sh
+++ b/config/backup_output.sh
@@ -2,7 +2,7 @@ OUTFILE='do_backup.pp'
 
 
 function write_output {
-
+	alfresco_base_dir=`get_param alfresco_base_dir`
   backup_at_hour=`get_param backup_at_hour`
   backup_at_min=`get_param backup_at_min`
   duplicity_password=`get_param duplicity_password`
@@ -31,6 +31,7 @@ function write_output {
 	echo -e "${GREEN}Writing puppet file ${BLUE}${OUTFILE}${WHITE}"
 	cat > ${OUTFILE} <<EOF
 class { 'alfresco::backup':
+	alfresco_base_dir => '${alfresco_base_dir}',
   backup_at_hour => '${backup_at_hour}',
   backup_at_min => '${backup_at_min}',
   duplicity_password => '${duplicity_password}',

--- a/config/backup_params.sh
+++ b/config/backup_params.sh
@@ -1,5 +1,11 @@
 
 IDX=0
+params[$IDX]="alfresco_base_dir"
+descr[$IDX]="Where is alfresco installed. This should already have been set by the initial setup"
+required[$IDX]=1
+
+
+IDX=$(( $IDX + 1 ))
 params[$IDX]="backuptype"
 descr[$IDX]="Type of backup. Choose one of the options and then configure the appropriate settings." 
 default[$IDX]="local"

--- a/config/backup_pre.sh
+++ b/config/backup_pre.sh
@@ -1,5 +1,10 @@
 #INSTALL_LETTER=
 #PROMPT="Please choose an index number to edit, or Q to quit"
 
+alfresco_base_dir=`cat go.pp | grep alfresco_base_dir | cut -f2 -d\'`
+echo "alfresco_base_dir=$alfresco_base_dir" >> config/backup_answers.sh
+
+
+
 INSTALL_LETTER=A
 PROMPT="Please choose an index number to edit, A to apply configuration, or Q to quit"

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,4 +1,5 @@
 class alfresco::backup (
+  $alfresco_base_dir,
   $backup_at_hour = 2,
   $backup_at_min = fqdn_rand(59),
   $duplicity_password = '',
@@ -22,7 +23,7 @@ class alfresco::backup (
   $scp_server = '',
   $scp_user = '',
   $scp_folder = '',
-) inherits alfresco {
+) {
   
 
   # TODO is there a safer way to make a password without using generate()

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -36,10 +36,6 @@ class alfresco::backup (
     ensure => present,
   }
 
-  file { "${alfresco_base_dir}/scripts":
-    ensure => directory,
-    require => File[$alfresco_base_dir],
-  } ->
   file { "${alfresco_base_dir}/scripts/alfresco-bart.sh":
     ensure => present,
     content => template('alfresco/alfresco-bart.sh.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,16 @@ class alfresco (
 	}
 
 
+	# write a config file for BART, will also make the templated files refer to these:
+  file { "${alfresco_base_dir}/scripts":
+	  ensure => directory,
+		require => File[$alfresco_base_dir],
+	} -> 
+	file { "${alfresco_base_dir}/scripts/bart.conf":
+		ensure => present,
+		content => "ALF_BASE_DIR=${alfresco_base_dir}\nINDEXER=${indexer}\nDB_NAME=${db_name}\nDB_PASS=${db_pass}\nDB_HOST=${db_host}\nDB_USER=${db_user}\n"
+	}
+
 
 	#http://askubuntu.com/a/519783/33804
 	if($osfamily == 'Debian'){

--- a/setup-backup.sh
+++ b/setup-backup.sh
@@ -8,4 +8,7 @@ then
 	exit
 fi
 
+# hmm this is going to a bit convoluted
+
+
 CONF=config/backup bashconf/bashconf.sh

--- a/templates/alfresco-bart.properties.erb
+++ b/templates/alfresco-bart.properties.erb
@@ -13,6 +13,7 @@
 # Latest code available at:
 # http://blyx.com/alfresco-bart
 #
+#
 #########################################################################################
 # alfresco-bart: ALFRESCO BACKUP AND RECOVERY TOOL 
 # Version 0.2       
@@ -22,6 +23,7 @@
 # for root (chmod 400 alfresco-bart.properties)
 # Copy this file in you ALFRESCO_INSTALLATION_PATH/scripts.
 #########################################################################################
+
 
 ## Logging
 # Log configuration
@@ -54,7 +56,7 @@ MAXFULL=<%= @maxfull %>
 VOLUME_SIZE=<%= @volume_size %>
 
 # Alfresco root installation path. It has to be a real directory not a symlink
-ALF_INSTALLATION_DIR=<%= @alfresco_base_dir %>
+ALF_INSTALLATION_DIR=$ALF_BASE_DIR
 
 # Alfresco alf_data path
 ALF_DIRROOT=${ALF_INSTALLATION_DIR}/alf_data
@@ -71,7 +73,7 @@ BACKUP_INDEX_ENABLED=true
 # Alfresco index type, use solr or lucene
 INDEXTYPE=solr
 # If Solr is selected, all Solr installation and config files will be included in your backup
-INDEXES_DIR=${ALF_DIRROOT}/<%= @indexer %>
+INDEXES_DIR=${ALF_DIRROOT}/${INDEXER}
 # If Lucene change to ${ALF_DIRROOT}/lucene
 # SOLR or Lucene backup location
 INDEXES_BACKUP_DIR=${ALF_DIRROOT}/solrBackup
@@ -93,10 +95,10 @@ LOCAL_DB_DIR=${ALF_DIRROOT}/postgresql
 DATE_FILE=`date +%Y-%m-%d_%H%M%S`
 
 # Global DB parameters
-DBNAME=<%= @db_name %>
-DBUSER=<%= @db_user %>
-DBPASS=<%= @db_pass %>
-DBHOST=<%= @db_host %>
+DBNAME=$DB_NAME
+DBUSER=$DB_USER
+DBPASS=$DB_PASS
+DBHOST=$DB_HOST
 
 # MySQL - Alfresco DB Configuration
 MYSQL_BINDIR=/usr/bin
@@ -178,9 +180,9 @@ REC_DBTYPE=mysql
 
 
 # MySQL - Recovery DB Configuration ##
-REC_MYDBNAME=<%= @db_name %>_rec
-REC_MYUSER=<%= @db_user %>
-REC_MYPASS=<%= @db_pass %>
+REC_MYDBNAME=${DB_NAME}_rec
+REC_MYUSER=${DB_USER}
+REC_MYPASS=${DB_PASS}
 REC_MYHOST=localhost
 REC_MYSQL_BIN=/usr/bin/mysql
 REC_MYSQLDUMP_BIN=/usr/bin/mysqldump

--- a/templates/alfresco-bart.sh.erb
+++ b/templates/alfresco-bart.sh.erb
@@ -32,7 +32,9 @@
 #########################################################################################
 
 # Load properties
-ALFBRT_PATH=<%= @alfresco_base_dir %>/scripts
+ALFBRT_PATH="`dirname $0`"
+
+source $ALFBRT_PATH/bart.conf
 
 if [ -f ${ALFBRT_PATH}/alfresco-bart.properties ]; then
 	. ${ALFBRT_PATH}/alfresco-bart.properties 


### PR DESCRIPTION
Finally fixes #43 - the previous way of including the main alfresco puppet build in order to get the configuration was pretty flawed, and basically ran the whole main alfresco build again; regardless of the fact that it should have been built already and therefore no impact was expected, in actual fact random resources wanted to run again, obviously was misunderstanding how that stuff was done. So with a bit of weird bootstrapping I managed to get the config into a shell script in the same location as the backup and source it from BART. and done.